### PR TITLE
pytest.warns requires at least pytest 2.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     version=version,
     url='http://github.com/mitsuhiko/click',
     packages=['click'],
+    tests_require=['pytest>=2.8'],
     description='A simple wrapper around optparse for '
                 'powerful command line utilities.',
     classifiers=[


### PR DESCRIPTION
Please merge this to your branch so it can be included in https://github.com/pallets/click/pull/838.  Thanks!

https://github.com/pytest-dev/pytest/blob/2.8.0/doc/en/recwarn.rst#asserting-warnings-with-the-warns-function